### PR TITLE
Post-hoc triggers/viewing whole phrase

### DIFF
--- a/src/VideoRemise/VideoRemise/MainPage.xaml.cs
+++ b/src/VideoRemise/VideoRemise/MainPage.xaml.cs
@@ -197,6 +197,12 @@ namespace VideoRemise
                         gridManager.OnPlaybackEvent(PlaybackEvent.Live);
                         SetStatus();
                         break;
+                    case VirtualKey.Escape:
+                        gridManager.OnPlaybackEvent(PlaybackEvent.Escape);
+                        break;
+                    case VirtualKey.Back:
+                        gridManager.OnPlaybackEvent(PlaybackEvent.ReTrigger);
+                        break;
                     case VirtualKey.Number0:
                         gridManager.OnPlaybackEvent(PlaybackEvent.Speed100);
                         break;

--- a/src/VideoRemise/VideoRemise/PhraseRecording.cs
+++ b/src/VideoRemise/VideoRemise/PhraseRecording.cs
@@ -12,20 +12,30 @@ namespace VideoRemise
 {
     internal class PhraseRecording
     {
-        private StorageFile file;
-        private TimeSpan replayLength;
-        private TriggerType triggerEvent;
+        internal readonly StorageFile file;
+        internal TimeSpan ReplayLength { get; set; }
+        internal TimeSpan? ReplayStart { get; set; }
+        internal TriggerType triggerEvent;
 
-        public PhraseRecording(StorageFile _file, TimeSpan _seconds, TriggerType _triggerEvent)
+        public PhraseRecording(StorageFile _file, TimeSpan _seconds, TimeSpan? _start, TriggerType _triggerEvent)
         {
             file = _file;
-            replayLength = _seconds;
+            ReplayLength = _seconds;
+            ReplayStart = _start;
             triggerEvent = _triggerEvent;
         }
 
-        public (MediaSource, TimeSpan) GetSourceAndLength()
+        public MediaSource GetSource()
         {
-            return (MediaSource.CreateFromStorageFile(file), replayLength);
+            return MediaSource.CreateFromStorageFile(file);
+        }
+
+        public PhraseRecording SplitAt(TimeSpan splitTime)
+        {
+            var newLength = VideoChannel.TSMin(splitTime, ReplayLength);
+            // Guaranteed to be at least 0
+            var newStart = splitTime - newLength;
+            return new PhraseRecording(file, newLength, newStart, triggerEvent);
         }
     }
 }

--- a/src/VideoRemise/VideoRemise/VideoChannel.cs
+++ b/src/VideoRemise/VideoRemise/VideoChannel.cs
@@ -30,6 +30,8 @@ namespace VideoRemise
         FrameForward,
         FrameBackward,
         Live,
+        Escape,
+        ReTrigger,
         Speed10,
         Speed20,
         Speed30,
@@ -68,6 +70,7 @@ namespace VideoRemise
         private bool isRecording = false;
         private bool showingLive = true;
         private bool playing = false;
+        private bool escaped = false;
 
         public MediaPlayerElement PlayerElement => mediaPlayerElement;
         public CaptureElement CaptureElement => captureElement;
@@ -224,6 +227,12 @@ namespace VideoRemise
                 case PlaybackEvent.Live:
                     Live();
                     break;
+                case PlaybackEvent.Escape:
+                    Escape();
+                    break;
+                case PlaybackEvent.ReTrigger:
+                    ReTrigger();
+                    break;
                 case PlaybackEvent.Speed10:
                     SetSpeed(.1);
                     break;
@@ -255,6 +264,37 @@ namespace VideoRemise
                     SetSpeed(1);
                     break;
             }
+        }
+
+        private void ReTrigger()
+        {
+            if (!escaped)
+            {
+                return;
+            }
+
+            mediaPlayerElement.MediaPlayer.Pause();
+            var phrase = actions.ElementAt(currentReplay);
+            var splitTime = mediaPlayerElement.MediaPlayer.PlaybackSession.Position;
+
+            // This always splits at the current time, allowing replay overlap (but I don't think that's a bad thing)
+            var newPhrase = phrase.SplitAt(splitTime);
+            actions.Insert(currentReplay, newPhrase);
+            PlayFromFile();
+        }
+
+        private async void Escape()
+        {
+            var phrase = actions.ElementAt(currentReplay);
+            var duration = mediaPlayerElement.MediaPlayer.PlaybackSession.NaturalDuration;
+            if (phrase.ReplayLength >= duration) {
+                await new MessageDialog("WARNING: Nothing to escape, the phrase recording is shorter than the replay length").ShowAsync();
+                return;
+            }
+            escaped = true;
+            mediaPlayerElement.MediaPlayer.Pause();
+            mediaPlayerElement.MediaPlayer.PlaybackSession.Position = TimeSpan.Zero;
+            mediaPlayerElement.MediaPlayer.Play();
         }
 
         internal void PlayPause()
@@ -307,6 +347,7 @@ namespace VideoRemise
             mediaPlayerElement.Visibility = Visibility.Collapsed;
             showingLive = true;
             playing = false;
+            escaped = false;
             mainPage.CurrentMode = Mode.Recording;
         }
 
@@ -336,7 +377,7 @@ namespace VideoRemise
             }
 
             await StopRecording();
-            PhraseRecording pr = new PhraseRecording(currentFile, length, triggerType);
+            PhraseRecording pr = new PhraseRecording(currentFile, length, null, triggerType);
             actions.Add(pr);
         }
 
@@ -359,15 +400,40 @@ namespace VideoRemise
             StartPlayback();
         }
 
-        internal void PlayFromFile()
+        // Todo: Kinda ugly
+        private void PlayFromFile()
         {
             captureElement.Visibility = Visibility.Collapsed;
             mediaPlayerElement.Visibility = Visibility.Visible;
             showingLive = false;
             playing = true;
+            escaped = false;
             mainPage.CurrentMode = Mode.Replaying;
 
-            var (source, length) = actions.ElementAt(currentReplay).GetSourceAndLength();
+            var phrase = actions.ElementAt(currentReplay);
+            var source = phrase.GetSource();
+            var start = phrase.ReplayStart;
+            var length = phrase.ReplayLength;
+
+            void StartLoop (MediaPlayer player) {
+                player.Pause();
+                if (escaped)
+                {
+                    player.PlaybackSession.Position = TimeSpan.Zero;
+                }
+                else if (start == null)
+                {
+                    var timeToBegin = player.PlaybackSession.NaturalDuration - length;
+                    player.PlaybackSession.Position = TSMax(TimeSpan.Zero, timeToBegin);
+                }
+                else
+                {
+                    player.PlaybackSession.Position = start.Value;
+                }
+
+                player.Play();
+            };
+
             // This has to come before the two event additions because otherwise there's
             // an odd runtime error adding the event hadler that "this" is null in the 
             // handler delegate. Maybe the MediaPlayer element doesn't get initialized
@@ -375,17 +441,29 @@ namespace VideoRemise
             mediaPlayerElement.Source = source;
             mediaPlayerElement.MediaPlayer.MediaOpened += (MediaPlayer sender, object args) =>
             {
-                var start = sender.PlaybackSession.NaturalDuration - length;
-                sender.PlaybackSession.Position = TimeSpan.FromSeconds(Math.Max(start.TotalSeconds, 0));
-                sender.Play();
+                StartLoop(sender);
             };
             mediaPlayerElement.MediaPlayer.MediaEnded += (MediaPlayer sender, object args) =>
             {
-                sender.Pause();
-                var start = sender.PlaybackSession.NaturalDuration - length;
-                sender.PlaybackSession.Position = TimeSpan.FromSeconds(Math.Max(start.TotalSeconds, 0));
-                sender.Play();
+                StartLoop(sender);
             };
+
+            if (start != null) {
+                mediaPlayerElement.MediaPlayer.PlaybackSession.PositionChanged += (MediaPlaybackSession session, object args) =>
+                {
+                    if (session.Position > start + length)
+                    {
+                        if (escaped)
+                        {
+                            session.Position = TimeSpan.Zero;
+                        }
+                        else
+                        {
+                            session.Position = start.Value;
+                        }
+                    }
+                };
+            }
         }
 
         internal void StartPlayback()
@@ -583,6 +661,30 @@ namespace VideoRemise
             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
+        }
+
+        internal static TimeSpan TSMax(TimeSpan ts1, TimeSpan ts2)
+        {
+            if (ts1 > ts2)
+            {
+                return ts1;
+            }
+            else
+            {
+                return ts2;
+            }
+        }
+
+        internal static TimeSpan TSMin(TimeSpan ts1, TimeSpan ts2)
+        {
+            if (ts1 < ts2)
+            {
+                return ts1;
+            }
+            else
+            {
+                return ts2;
+            }
         }
     }
 }


### PR DESCRIPTION
Addresses https://github.com/alan-geller/video-remise/issues/5

Adds support for multiple replays from a single video file by adding an optional start time and an event handler to restart the loop when the position changes past the end time.

Adds an escape hatch (`escape`), that allows watching the entire phrase recording, and a button to trigger after the fact, creating a new replay action (`backspace`).