### PR TITLE
Add support for tagging and navigating tagged replays

### DIFF
--- a/src/VideoRemise/VideoRemise/MainPage.xaml.cs
+++ b/src/VideoRemise/VideoRemise/MainPage.xaml.cs
@@ -47,6 +47,11 @@ namespace VideoRemise
                 if (CurrentMode != Mode.Idle)
                 {
                     e.Handled = true;
+                    if (e.Key == VirtualKey.Tab)
+                    {
+                        gridManager.OnPlaybackEvent(PlaybackEvent.Tag);
+                        SetStatus();
+                    }
                 }
             };
             Active = false;
@@ -176,10 +181,24 @@ namespace VideoRemise
                 switch (e.VirtualKey)
                 {
                     case VirtualKey.PageDown:
-                        gridManager.OnPlaybackEvent(PlaybackEvent.Backward);
+                        if (Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift) == CoreVirtualKeyStates.Down)
+                        {
+                            gridManager.OnPlaybackEvent(PlaybackEvent.BackwardTag);
+                        }
+                        else
+                        {
+                            gridManager.OnPlaybackEvent(PlaybackEvent.Backward);
+                        }
                         break;
                     case VirtualKey.PageUp:
-                        gridManager.OnPlaybackEvent(PlaybackEvent.Forward);
+                        if (Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift) == CoreVirtualKeyStates.Down)
+                        {
+                            gridManager.OnPlaybackEvent(PlaybackEvent.ForwardTag);
+                        }
+                        else
+                        {
+                            gridManager.OnPlaybackEvent(PlaybackEvent.Forward);
+                        }
                         break;
                     case VirtualKey.Space:
                         gridManager.OnPlaybackEvent(PlaybackEvent.PlayPause);

--- a/src/VideoRemise/VideoRemise/PhraseRecording.cs
+++ b/src/VideoRemise/VideoRemise/PhraseRecording.cs
@@ -15,6 +15,7 @@ namespace VideoRemise
         private StorageFile file;
         private TimeSpan replayLength;
         private TriggerType triggerEvent;
+        internal bool Tag { get; set; }
 
         public PhraseRecording(StorageFile _file, TimeSpan _seconds, TriggerType _triggerEvent)
         {

--- a/src/VideoRemise/VideoRemise/VideoChannel.cs
+++ b/src/VideoRemise/VideoRemise/VideoChannel.cs
@@ -30,6 +30,9 @@ namespace VideoRemise
         FrameForward,
         FrameBackward,
         Live,
+        ForwardTag,
+        BackwardTag,
+        Tag,
         Speed10,
         Speed20,
         Speed30,
@@ -224,6 +227,15 @@ namespace VideoRemise
                 case PlaybackEvent.Live:
                     Live();
                     break;
+                case PlaybackEvent.ForwardTag:
+                    ForwardTag();
+                    break;
+                case PlaybackEvent.BackwardTag:
+                    BackwardTag();
+                    break;
+                case PlaybackEvent.Tag:
+                    Tag();
+                    break;
                 case PlaybackEvent.Speed10:
                     SetSpeed(.1);
                     break;
@@ -308,6 +320,42 @@ namespace VideoRemise
             showingLive = true;
             playing = false;
             mainPage.CurrentMode = Mode.Recording;
+        }
+
+        internal async void BackwardTag()
+        {
+            for (var i = currentReplay - 1; i >= 0; i--)
+            {
+                if (actions.ElementAt(i).Tag)
+                {
+                    currentReplay = i;
+                    PlayFromFile();
+                    return;
+                }
+            }
+
+            await (new MessageDialog("No more tagged videos before this one")).ShowAsync();
+        }
+
+        internal async void ForwardTag()
+        {
+            for (var i = currentReplay + 1; i < actions.Count; i++)
+            {
+                if (actions.ElementAt(i).Tag)
+                {
+                    currentReplay = i;
+                    PlayFromFile();
+                    return;
+                }
+            }
+
+            await (new MessageDialog("No more tagged videos after this one")).ShowAsync();
+        }
+
+        internal void Tag()
+        {
+            var phrase = actions.ElementAt(currentReplay);
+            phrase.Tag = true;
         }
 
         internal async Task<IAsyncAction> StartRecording(string fileBaseName)


### PR DESCRIPTION
Allows tagging replays using `tab` while replaying, and navigating between tagged replays using `shift + PgUp` and `shift + PgDn`