### PR TITLE
Fix logic for entering/exiting focus mode

### DIFF
--- a/src/VideoRemise/VideoRemise/MainPage.xaml.cs
+++ b/src/VideoRemise/VideoRemise/MainPage.xaml.cs
@@ -333,8 +333,11 @@ namespace VideoRemise
                 //        config.ReplaySecondsBeforeTrigger[CurrentWeapon]);
                 //}
                 gridManager.OnHalt(TriggerType.Halt);
-                CurrentMode = Mode.Replaying;
-                SetStatus();
+                if (CurrentMode != Mode.Focused)
+                {
+                    CurrentMode = Mode.Replaying;
+                    SetStatus();
+                }
             }
         }
 

--- a/src/VideoRemise/VideoRemise/VideoChannel.cs
+++ b/src/VideoRemise/VideoRemise/VideoChannel.cs
@@ -361,6 +361,7 @@ namespace VideoRemise
             showingLive = true;
             playing = false;
             escaped = false;
+            focused = false;
             mainPage.CurrentMode = Mode.Recording;
         }
 
@@ -396,6 +397,12 @@ namespace VideoRemise
 
         internal void Tag()
         {
+            if (focused)
+            {
+                focused = false;
+                return;
+            }
+
             var phrase = actions.ElementAt(currentReplay);
             phrase.Tag = true;
             focused = true;

--- a/src/VideoRemise/VideoRemise/VideoGridManager.cs
+++ b/src/VideoRemise/VideoRemise/VideoGridManager.cs
@@ -169,8 +169,10 @@ namespace VideoRemise
             {
                 channel.StartPlayback();
             }
-            mainPage.CurrentMode = Mode.Replaying;
-            mainPage.SetStatus();
+            if (mainPage.CurrentMode != Mode.Focused) {
+                mainPage.CurrentMode = Mode.Replaying;
+                mainPage.SetStatus();
+            }
         }
 
         internal void OnPlaybackEvent(PlaybackEvent playbackEvent)
@@ -194,8 +196,11 @@ namespace VideoRemise
                 channel.Trigger(replayDurationBeforeTrigger + replayDurationAfterTrigger, 
                     triggerType);
             }
-            mainPage.CurrentMode = Mode.Replaying;
-            mainPage.SetStatus();
+            if (mainPage.CurrentMode != Mode.Focused)
+            {
+                mainPage.CurrentMode = Mode.Replaying;
+                mainPage.SetStatus();
+            }
         }
 
         private void OnLightStatus(object sender, Trigger.LightEventArgs args)


### PR DESCRIPTION
Fully addresses #16 (previously, this was an unfinished and buggy feature), exacerbates #3.